### PR TITLE
Invert trusted network policy toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dot as a legal character in host profile title. [#22](https://github.com/keeshux/passepartout-ios/issues/22)
 - Host profiles can now be renamed. [#24](https://github.com/keeshux/passepartout-ios/issues/24)
 
+### Changed
+
+- Disconnect VPN by default when entering a trusted network. [#25](https://github.com/passepartoutvpn/passepartout-ios/pull/25)
+
 ### Removed
 
 - "Test connectivity" until it's more transparent.

--- a/Passepartout-iOS/Scenes/ServiceViewController.swift
+++ b/Passepartout-iOS/Scenes/ServiceViewController.swift
@@ -293,14 +293,14 @@ class ServiceViewController: UIViewController, TableModelHost {
         }
     }
     
-    private func toggleRetainTrustedConnection(_ isOn: Bool, sender: ToggleTableViewCell) {
+    private func toggleTrustedConnectionPolicy(_ isOn: Bool, sender: ToggleTableViewCell) {
         let completionHandler: () -> Void = {
-            self.service.preferences.trustPolicy = isOn ? .ignore : .disconnect
+            self.service.preferences.trustPolicy = isOn ? .disconnect : .ignore
             if self.vpn.isEnabled {
                 self.vpn.reinstall(completionHandler: nil)
             }
         }
-        guard !isOn else {
+        guard isOn else {
             completionHandler()
             return
         }
@@ -316,7 +316,7 @@ class ServiceViewController: UIViewController, TableModelHost {
             completionHandler()
         }
         alert.addCancelAction(L10n.Global.cancel) {
-            sender.setOn(true, animated: true)
+            sender.setOn(false, animated: true)
         }
         present(alert, animated: true, completion: nil)
     }
@@ -664,7 +664,7 @@ extension ServiceViewController: UITableViewDataSource, UITableViewDelegate, Tog
         case .trustedPolicy:
             let cell = Cells.toggle.dequeue(from: tableView, for: indexPath, tag: row.rawValue, delegate: self)
             cell.caption = L10n.Service.Cells.TrustedPolicy.caption
-            cell.isOn = (service.preferences.trustPolicy == .ignore)
+            cell.isOn = (service.preferences.trustPolicy == .disconnect)
             return cell
             
         // diagnostics
@@ -826,7 +826,7 @@ extension ServiceViewController: UITableViewDataSource, UITableViewDelegate, Tog
             }
             
         case .trustedPolicy:
-            toggleRetainTrustedConnection(cell.isOn, sender: cell)
+            toggleTrustedConnectionPolicy(cell.isOn, sender: cell)
             
         default:
             break

--- a/Passepartout/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Resources/en.lproj/Localizable.strings
@@ -75,7 +75,7 @@
 "service.sections.vpn_resolves_hostname.footer" = "Preferred in most networks and required in some IPv6 networks. Disable where DNS is blocked, or to speed up negotiation when DNS is slow to respond.";
 //"service.sections.vpn_prefers_udp.footer" = "UDP is faster than TCP, but may not work in some networks. Disable in networks where UDP might be blocked.";
 "service.sections.trusted.header" = "Trusted networks";
-"service.sections.trusted.footer" = "When entering a trusted network, the VPN connection is normally shut down and kept disconnected. Disable this option to allow manual VPN connections.";
+"service.sections.trusted.footer" = "When entering a trusted network, the VPN is normally shut down and kept disconnected. Disable this option to not enforce such behavior.";
 "service.sections.diagnostics.header" = "Diagnostics";
 //"service.sections.destruction.footer" = "Delete configuration from device settings.";
 
@@ -100,7 +100,7 @@
 "service.cells.trusted_mobile.caption" = "Cellular network";
 "service.cells.trusted_wifi.caption" = "%@";
 "service.cells.trusted_add_wifi.caption" = "Add current Wi-Fi";
-"service.cells.trusted_policy.caption" = "Disconnect VPN when trusted";
+"service.cells.trusted_policy.caption" = "Trust disables VPN";
 "service.cells.test_connectivity.caption" = "Test connectivity";
 "service.cells.data_count.caption" = "Exchanged bytes count";
 "service.cells.debug_log.caption" = "Debug log";

--- a/Passepartout/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Resources/en.lproj/Localizable.strings
@@ -75,7 +75,7 @@
 "service.sections.vpn_resolves_hostname.footer" = "Preferred in most networks and required in some IPv6 networks. Disable where DNS is blocked, or to speed up negotiation when DNS is slow to respond.";
 //"service.sections.vpn_prefers_udp.footer" = "UDP is faster than TCP, but may not work in some networks. Disable in networks where UDP might be blocked.";
 "service.sections.trusted.header" = "Trusted networks";
-"service.sections.trusted.footer" = "When entering a trusted network, an existing VPN connection will not be shut down by default. Disable to always enforce a disconnection.";
+"service.sections.trusted.footer" = "When entering a trusted network, the VPN connection is normally shut down and kept disconnected. Disable this option to allow manual VPN connections.";
 "service.sections.diagnostics.header" = "Diagnostics";
 //"service.sections.destruction.footer" = "Delete configuration from device settings.";
 
@@ -100,7 +100,7 @@
 "service.cells.trusted_mobile.caption" = "Cellular network";
 "service.cells.trusted_wifi.caption" = "%@";
 "service.cells.trusted_add_wifi.caption" = "Add current Wi-Fi";
-"service.cells.trusted_policy.caption" = "Retain existing connection";
+"service.cells.trusted_policy.caption" = "Disconnect VPN when trusted";
 "service.cells.test_connectivity.caption" = "Test connectivity";
 "service.cells.data_count.caption" = "Exchanged bytes count";
 "service.cells.debug_log.caption" = "Debug log";

--- a/Passepartout/Sources/SwiftGen+Strings.swift
+++ b/Passepartout/Sources/SwiftGen+Strings.swift
@@ -532,7 +532,7 @@ internal enum L10n {
         internal static let caption = L10n.tr("Localizable", "service.cells.trusted_mobile.caption")
       }
       internal enum TrustedPolicy {
-        /// Retain existing connection
+        /// Disconnect VPN when trusted
         internal static let caption = L10n.tr("Localizable", "service.cells.trusted_policy.caption")
       }
       internal enum TrustedWifi {
@@ -582,7 +582,7 @@ internal enum L10n {
         internal static let header = L10n.tr("Localizable", "service.sections.status.header")
       }
       internal enum Trusted {
-        /// When entering a trusted network, an existing VPN connection will not be shut down by default. Disable to always enforce a disconnection.
+        /// When entering a trusted network, the VPN connection is normally shut down and kept disconnected. Disable this option to allow manual VPN connections.
         internal static let footer = L10n.tr("Localizable", "service.sections.trusted.footer")
         /// Trusted networks
         internal static let header = L10n.tr("Localizable", "service.sections.trusted.header")

--- a/Passepartout/Sources/SwiftGen+Strings.swift
+++ b/Passepartout/Sources/SwiftGen+Strings.swift
@@ -532,7 +532,7 @@ internal enum L10n {
         internal static let caption = L10n.tr("Localizable", "service.cells.trusted_mobile.caption")
       }
       internal enum TrustedPolicy {
-        /// Disconnect VPN when trusted
+        /// Trust disables VPN
         internal static let caption = L10n.tr("Localizable", "service.cells.trusted_policy.caption")
       }
       internal enum TrustedWifi {
@@ -582,7 +582,7 @@ internal enum L10n {
         internal static let header = L10n.tr("Localizable", "service.sections.status.header")
       }
       internal enum Trusted {
-        /// When entering a trusted network, the VPN connection is normally shut down and kept disconnected. Disable this option to allow manual VPN connections.
+        /// When entering a trusted network, the VPN connection is normally shut down and disabled. Disable this option to not enforce this behavior.
         internal static let footer = L10n.tr("Localizable", "service.sections.trusted.footer")
         /// Trusted networks
         internal static let header = L10n.tr("Localizable", "service.sections.trusted.header")


### PR DESCRIPTION
Looks more intuitive when defaults to "Disconnect VPN when trusted" (ON). Also reworded accordingly.