### PR TITLE
Default "Automatic" protocol to UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ProtonVPN provider. [#7](https://github.com/passepartoutvpn/passepartout-ios/issues/7)
 - Italian translations. [#58](https://github.com/passepartoutvpn/passepartout-ios/pull/58)
 
+### Changed
+
+- Automatic protocol defaults to UDP endpoints. [#61](https://github.com/passepartoutvpn/passepartout-ios/pull/61)
+
 ### Fixed
 
 - Some providers may crash on VPN activation. [#57](https://github.com/passepartoutvpn/passepartout-ios/issues/57)

--- a/Passepartout/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Resources/en.lproj/Localizable.strings
@@ -148,8 +148,8 @@
 
 "endpoint.sections.location_addresses.header" = "Addresses";
 "endpoint.sections.location_protocols.header" = "Protocols";
-"endpoint.cells.any_address.caption" = "Any";
-"endpoint.cells.any_protocol.caption" = "Any";
+"endpoint.cells.any_address.caption" = "Automatic";
+"endpoint.cells.any_protocol.caption" = "Automatic";
 
 "provider.preset.cells.tech_details.caption" = "Technical details";
 //"provider.preset.sections.main.footer" = "Tap info button to disclose technical details.";

--- a/Passepartout/Resources/it.lproj/Localizable.strings
+++ b/Passepartout/Resources/it.lproj/Localizable.strings
@@ -144,8 +144,8 @@
 
 "endpoint.sections.location_addresses.header" = "Indirizzi";
 "endpoint.sections.location_protocols.header" = "Protocolli";
-"endpoint.cells.any_address.caption" = "Qualunque";
-"endpoint.cells.any_protocol.caption" = "Qualunque";
+"endpoint.cells.any_address.caption" = "Automatico";
+"endpoint.cells.any_protocol.caption" = "Automatico";
 
 "provider.preset.cells.tech_details.caption" = "Dettagli tecnici";
 //"provider.preset.sections.main.footer" = "Tap info button to disclose technical details.";

--- a/Passepartout/Sources/Model/Profiles/ProviderConnectionProfile.swift
+++ b/Passepartout/Sources/Model/Profiles/ProviderConnectionProfile.swift
@@ -132,7 +132,15 @@ public class ProviderConnectionProfile: ConnectionProfile, Codable, Equatable {
         if let proto = manualProtocol {
             builder.sessionConfiguration.endpointProtocols = [proto]
         } else {
-            builder.sessionConfiguration.endpointProtocols = preset.configuration.sessionConfiguration.endpointProtocols
+            
+            // restrict "Any" protocol to UDP, unless there are no UDP endpoints
+            let allEndpoints = preset.configuration.sessionConfiguration.endpointProtocols
+            var endpoints = allEndpoints?.filter { $0.socketType == .udp }
+            if endpoints?.isEmpty ?? true {
+                endpoints = allEndpoints
+            }
+            
+            builder.sessionConfiguration.endpointProtocols = endpoints
 //            builder.sessionConfiguration.endpointProtocols = [
 //                EndpointProtocol(.udp, 8080),
 //                EndpointProtocol(.tcp, 443)

--- a/Passepartout/Sources/SwiftGen+Strings.swift
+++ b/Passepartout/Sources/SwiftGen+Strings.swift
@@ -298,11 +298,11 @@ public enum L10n {
   public enum Endpoint {
     public enum Cells {
       public enum AnyAddress {
-        /// Any
+        /// Automatic
         public static let caption = L10n.tr("Localizable", "endpoint.cells.any_address.caption")
       }
       public enum AnyProtocol {
-        /// Any
+        /// Automatic
         public static let caption = L10n.tr("Localizable", "endpoint.cells.any_protocol.caption")
       }
     }


### PR DESCRIPTION
When `randomizeEndpoint = true`, users may happen to connect via TCP even when UDP is viable. Restrict "Automatic" protocol to UDP endpoints only. Users wanting to use TCP will pick a TCP endpoint manually.