### PR TITLE
Do not imply default gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Do not redirect all traffic to VPN unless `--redirect-gateway` specified. [#71](https://github.com/passepartoutvpn/passepartout-ios/pull/71)
+
 ## 1.6.0 Beta 1750 (2019-04-23)
 
 ### Added

--- a/Passepartout-iOS/Scenes/ConfigurationViewController.swift
+++ b/Passepartout-iOS/Scenes/ConfigurationViewController.swift
@@ -87,6 +87,7 @@ class ConfigurationViewController: UIViewController, TableModelHost {
         } else {
             networkRows = []
         }
+        networkRows.insert(.defaultGateway, at: 0)
         networkRows.append(.dnsDomain)
         networkRows.append(.httpProxy)
         networkRows.append(.httpsProxy)
@@ -197,6 +198,8 @@ extension ConfigurationViewController: UITableViewDataSource, UITableViewDelegat
         
         case compressionAlgorithm
         
+        case defaultGateway
+        
         case dnsServer
         
         case dnsDomain
@@ -304,12 +307,22 @@ extension ConfigurationViewController: UITableViewDataSource, UITableViewDelegat
             cell.accessoryType = .none
             cell.isTappable = false
             
+        case .defaultGateway:
+            cell.leftText = L10n.Configuration.Cells.DefaultGateway.caption
+            if let policies = configuration.routingPolicies {
+                cell.rightText = policies.map { $0.rawValue }.joined(separator: " / ")
+            } else {
+                cell.rightText = V.All.Value.none
+            }
+            cell.accessoryType = .none
+            cell.isTappable = false
+
         case .dnsServer:
             guard let dnsServers = configuration.dnsServers else {
                 fatalError("Showing DNS section without any custom server")
             }
             cell.leftText = L10n.Configuration.Cells.DnsServer.caption
-            cell.rightText = dnsServers[indexPath.row]
+            cell.rightText = dnsServers[indexPath.row - 1]
             cell.accessoryType = .none
             cell.isTappable = false
             

--- a/Passepartout/Resources/en.lproj/Localizable.strings
+++ b/Passepartout/Resources/en.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "configuration.cells.tls_wrapping.value.auth" = "Authentication";
 "configuration.cells.tls_wrapping.value.crypt" = "Encryption";
 "configuration.cells.eku.caption" = "Extended verification";
+"configuration.cells.default_gateway.caption" = "Default gateway";
 "configuration.cells.dns_server.caption" = "DNS";
 "configuration.cells.dns_domain.caption" = "Domain";
 "configuration.cells.proxy_http.caption" = "Proxy";

--- a/Passepartout/Sources/Services/InfrastructurePreset.swift
+++ b/Passepartout/Sources/Services/InfrastructurePreset.swift
@@ -162,6 +162,9 @@ public struct InfrastructurePreset: Codable {
         sessionBuilder.randomizeEndpoint = try cfgContainer.decodeIfPresent(Bool.self, forKey: .randomizeEndpoint) ?? false
         sessionBuilder.usesPIAPatches = try cfgContainer.decodeIfPresent(Bool.self, forKey: .usesPIAPatches) ?? false
 
+        // XXX: redirect everything through the VPN for providers
+        sessionBuilder.routingPolicies = [.IPv4, .IPv6]
+        
         let builder = TunnelKitProvider.ConfigurationBuilder(sessionConfiguration: sessionBuilder.build())
         configuration = builder.build()
     }

--- a/Passepartout/Sources/SwiftGen+Strings.swift
+++ b/Passepartout/Sources/SwiftGen+Strings.swift
@@ -168,6 +168,10 @@ public enum L10n {
           public static let lzo = L10n.tr("Localizable", "configuration.cells.compression_framing.value.lzo")
         }
       }
+      public enum DefaultGateway {
+        /// Default gateway
+        public static let caption = L10n.tr("Localizable", "configuration.cells.default_gateway.caption")
+      }
       public enum Digest {
         /// Authentication
         public static let caption = L10n.tr("Localizable", "configuration.cells.digest.caption")

--- a/Podfile
+++ b/Podfile
@@ -5,8 +5,8 @@ use_frameworks!
 def shared_pods
     #pod 'TunnelKit', '~> 1.6.2'
     #pod 'TunnelKit/LZO', '~> 1.6.2'
-    pod 'TunnelKit', :git => 'https://github.com/keeshux/tunnelkit', :commit => 'ef5180a'
-    pod 'TunnelKit/LZO', :git => 'https://github.com/keeshux/tunnelkit', :commit => 'ef5180a'
+    pod 'TunnelKit', :git => 'https://github.com/keeshux/tunnelkit', :commit => '7382616'
+    pod 'TunnelKit/LZO', :git => 'https://github.com/keeshux/tunnelkit', :commit => '7382616'
     #pod 'TunnelKit', :path => '../../personal/tunnelkit'
     #pod 'TunnelKit/LZO', :path => '../../personal/tunnelkit'
     pod 'SSZipArchive'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,8 +17,8 @@ PODS:
 DEPENDENCIES:
   - MBProgressHUD
   - SSZipArchive
-  - TunnelKit (from `https://github.com/keeshux/tunnelkit`, commit `ef5180a`)
-  - TunnelKit/LZO (from `https://github.com/keeshux/tunnelkit`, commit `ef5180a`)
+  - TunnelKit (from `https://github.com/keeshux/tunnelkit`, commit `7382616`)
+  - TunnelKit/LZO (from `https://github.com/keeshux/tunnelkit`, commit `7382616`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -29,12 +29,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   TunnelKit:
-    :commit: ef5180a
+    :commit: '7382616'
     :git: https://github.com/keeshux/tunnelkit
 
 CHECKOUT OPTIONS:
   TunnelKit:
-    :commit: ef5180a
+    :commit: '7382616'
     :git: https://github.com/keeshux/tunnelkit
 
 SPEC CHECKSUMS:
@@ -44,6 +44,6 @@ SPEC CHECKSUMS:
   SwiftyBeaver: 4cc0080d2e23f980652e28978db11a5c9da39165
   TunnelKit: a0b7eb151ae6d30788623df94d682ed90706940a
 
-PODFILE CHECKSUM: 15e1a3ee168932349294032eeddea0f0713873a4
+PODFILE CHECKSUM: 15a7ba649b5eafa958016880cee196b53e08bf1f
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
So far, all the traffic has been redirected through the VPN by default. Instead:

- Providers: keep enforcing this behavior (normally preferred)
- Hosts: redirect according to `redirect-gateway` in the .ovpn configuration

Currently, it's an all-or-nothing option, in that the presence of the option implies that ALL traffic goes through the VPN. This will be refined later for proper split tunnelling.

**BEWARE**: host profiles formerly imported without `redirect-gateway` set **will not go through the VPN anymore**, as this is the standard OpenVPN behavior. Therefore, it's strongly suggested to fix your .ovpn file by adding `redirect-gateway` and reimport the profile.

In the future, there will be a way to change the default gateway right in the UI.

Related:

- https://github.com/keeshux/tunnelkit/issues/90
- https://github.com/keeshux/tunnelkit/issues/81
- https://github.com/keeshux/tunnelkit/issues/55