### PR TITLE
Wrong provider eligibility

### DIFF
--- a/Passepartout-iOS/Global/Product.swift
+++ b/Passepartout-iOS/Global/Product.swift
@@ -137,7 +137,7 @@ struct Product: RawRepresentable, Equatable, Hashable {
 
 extension Infrastructure.Metadata {
     var product: Product {
-        return Product(providerId: inApp ?? description)
+        return Product(providerId: inApp ?? name)
     }
 }
 

--- a/Passepartout-iOS/Global/ProductManager.swift
+++ b/Passepartout-iOS/Global/ProductManager.swift
@@ -173,13 +173,11 @@ class ProductManager: NSObject {
         return purchasedFeatures.contains(feature)
     }
 
-    func isEligible(forProvider name: Infrastructure.Name) -> Bool {
+    func isEligible(forProvider metadata: Infrastructure.Metadata) -> Bool {
         guard !isFullVersion() else {
             return true
         }
-        return purchasedFeatures.contains {
-            return $0.rawValue.hasSuffix("providers.\(name)")
-        }
+        return purchasedFeatures.contains(metadata.product)
     }
 
     func isEligibleForFeedback() -> Bool {
@@ -228,7 +226,10 @@ class ProductManager: NSObject {
 
         log.debug("Checking providers")
         for name in service.currentProviderNames() {
-            if !isEligible(forProvider: name) {
+            guard let metadata = InfrastructureFactory.shared.metadata(forName: name) else {
+                continue
+            }
+            if !isEligible(forProvider: metadata) {
                 service.removeProfile(ProfileKey(name))
                 log.debug("\tRefunded provider: \(name)")
                 anyRefund = true

--- a/Passepartout-iOS/Global/ProductManager.swift
+++ b/Passepartout-iOS/Global/ProductManager.swift
@@ -167,17 +167,11 @@ class ProductManager: NSObject {
     }
     
     func isEligible(forFeature feature: Product) -> Bool {
-        guard !isFullVersion() else {
-            return true
-        }
-        return purchasedFeatures.contains(feature)
+        return isFullVersion() || purchasedFeatures.contains(feature)
     }
 
     func isEligible(forProvider metadata: Infrastructure.Metadata) -> Bool {
-        guard !isFullVersion() else {
-            return true
-        }
-        return purchasedFeatures.contains(metadata.product)
+        return isFullVersion() || purchasedFeatures.contains(metadata.product)
     }
 
     func isEligibleForFeedback() -> Bool {

--- a/Passepartout-iOS/Scenes/Organizer/WizardProviderViewController.swift
+++ b/Passepartout-iOS/Scenes/Organizer/WizardProviderViewController.swift
@@ -63,7 +63,7 @@ class WizardProviderViewController: UITableViewController, StrongTableHost {
     private func tryNext(withMetadata metadata: Infrastructure.Metadata) {
         selectedMetadata = metadata
 
-        guard ProductManager.shared.isEligible(forProvider: metadata.name) else {
+        guard ProductManager.shared.isEligible(forProvider: metadata) else {
             presentPurchaseScreen(forProduct: metadata.product, delegate: self)
             return
         }


### PR DESCRIPTION
As pointed out in https://www.reddit.com/r/passepartout/comments/edh8yj/restore_purchases_not_working/, version 1.10.0 has a bug in how providers are checked for eligibility. The effect is that:

- New purchasers can't use the provider after purchase
- Old purchasers have their provider profile deleted and can't restore it

This PR fixes the naïve yet extremely annoying issue.